### PR TITLE
User all lower case for configuration keys, so that they can be

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ haystack:
      prefix: "haystack" # using something other than "haystack" will require a change in the InfluxDb template
      address: "haystack.local" # set in /etc/hosts per instructions in haystack/deployment module
      port: 2003 # Graphite port; typically 2003
-     pollIntervalSeconds: 60
-     queueSize: 10
+     pollintervalseconds: 60
+     queuesize: 10
 ```
 ### Graphite Bridge
 The "Graphite Bridge" connects Servo metrics from the application to the Haystack InfluxDb via Graphite 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-metrics</artifactId>
-    <version>0.1</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/metrics/GraphiteConfig.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/GraphiteConfig.java
@@ -39,12 +39,12 @@ public interface GraphiteConfig {
      *
      * @return the poll interval, in seconds
      */
-    int pollIntervalSeconds();
+    int pollintervalseconds();
 
     /**
      * The queue size of the asynchronous metric observer that polls metric data to send to Graphite
      *
      * @return the queue size to use
      */
-    int queueSize();
+    int queuesize();
 }

--- a/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
@@ -75,7 +75,7 @@ public class MetricPublishing {
         final MetricPoller monitorRegistryMetricPoller = factory.createMonitorRegistryMetricPoller();
         final List<MetricObserver> observers = Collections.singletonList(createGraphiteObserver(graphiteConfig));
         final PollRunnable task = factory.createTask(monitorRegistryMetricPoller, observers);
-        pollScheduler.addPoller(task, graphiteConfig.pollIntervalSeconds(), TimeUnit.SECONDS);
+        pollScheduler.addPoller(task, graphiteConfig.pollintervalseconds(), TimeUnit.SECONDS);
     }
 
     MetricObserver createGraphiteObserver(GraphiteConfig graphiteConfig) {
@@ -85,13 +85,13 @@ public class MetricPublishing {
     }
 
     MetricObserver rateTransform(GraphiteConfig graphiteConfig, MetricObserver observer) {
-        final long heartbeat = POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER * graphiteConfig.pollIntervalSeconds();
+        final long heartbeat = POLL_INTERVAL_SECONDS_TO_HEARTBEAT_MULTIPLIER * graphiteConfig.pollintervalseconds();
         return factory.createCounterToRateMetricTransform(observer, heartbeat, TimeUnit.SECONDS);
     }
 
     MetricObserver async(GraphiteConfig graphiteConfig, MetricObserver observer) {
-        final long expireTime = POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER * graphiteConfig.pollIntervalSeconds();
-        final int queueSize = graphiteConfig.queueSize();
+        final long expireTime = POLL_INTERVAL_SECONDS_TO_EXPIRE_TIME_MULTIPLIER * graphiteConfig.pollintervalseconds();
+        final int queueSize = graphiteConfig.queuesize();
         return factory.createAsyncMetricObserver(observer, queueSize, expireTime);
     }
 

--- a/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
@@ -159,12 +159,12 @@ public class MetricPublishingTest {
     private void whensForRateTransform() {
         when(mockFactory.createCounterToRateMetricTransform(any(MetricObserver.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(mockCounterToRateMetricTransform);
-        when(mockGraphiteConfig.pollIntervalSeconds()).thenReturn(POLL_INTERVAL_SECONDS);
+        when(mockGraphiteConfig.pollintervalseconds()).thenReturn(POLL_INTERVAL_SECONDS);
     }
 
     private void verifiesForRateTransform(int pollIntervalSecondsTimes, MetricObserver metricObserver) {
         verify(mockFactory).createCounterToRateMetricTransform(metricObserver, HEARTBEAT, TimeUnit.SECONDS);
-        verify(mockGraphiteConfig, times(pollIntervalSecondsTimes)).pollIntervalSeconds();
+        verify(mockGraphiteConfig, times(pollIntervalSecondsTimes)).pollintervalseconds();
     }
 
     @Test
@@ -178,15 +178,15 @@ public class MetricPublishingTest {
     }
 
     private void whensForAsync() {
-        when(mockGraphiteConfig.pollIntervalSeconds()).thenReturn(POLL_INTERVAL_SECONDS);
-        when(mockGraphiteConfig.queueSize()).thenReturn(QUEUE_SIZE);
+        when(mockGraphiteConfig.pollintervalseconds()).thenReturn(POLL_INTERVAL_SECONDS);
+        when(mockGraphiteConfig.queuesize()).thenReturn(QUEUE_SIZE);
         when(mockFactory.createAsyncMetricObserver(any(MetricObserver.class), anyInt(), anyLong()))
                 .thenReturn(mockAsyncMetricObserver);
     }
 
     private void verifiesForAsync(int pollIntervalSecondsTimes, MetricObserver metricObserver) {
-        verify(mockGraphiteConfig, times(pollIntervalSecondsTimes)).pollIntervalSeconds();
-        verify(mockGraphiteConfig).queueSize();
+        verify(mockGraphiteConfig, times(pollIntervalSecondsTimes)).pollintervalseconds();
+        verify(mockGraphiteConfig).queuesize();
         verify(mockFactory).createAsyncMetricObserver(
                 metricObserver, QUEUE_SIZE, EXPIRE_TIME);
     }


### PR DESCRIPTION
overridden by environment variables (the configuration source object
doesn't know how to convert all upper case environment variables keys
to camel case)