### PR TITLE
Only start the poll scheduler if it isn't already started.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.2.4 / 2017-11-20 Only call pollScheduler.start() if it is not already started
+As this haystack-metrics package is used more frequently and in different software layers, it's possible for multiple
+callers to request that the metrics polling thread be started, but this call must only be made once for each
+PollScheduler. (Typically there is only one PollScheduler, because `PollScheduler.getInstance()` is a singleton.)
+So `MetricPublishing.start(GraphiteConfig)` now has a `synchronized (pollScheduler)` block in which 
+`pollScheduler.isStarted()` is called, and the call to `pollScheduler.start()` is made if and only if
+`pollScheduler.isStarted()` returns false.
+
 ## 0.2.3 / 2017-11-16 Add MetricPublishing.stop() method
 Exposing a stop() method permits users of haystack-metrics to stop the metrics polling when required (for example, 
 when shutting down the system).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-metrics</artifactId>
-    <version>0.2.3-SNAPSHOT</version>
+    <version>0.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/metrics/GraphiteConfigImpl.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/GraphiteConfigImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.metrics;
 
 /**

--- a/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
@@ -66,16 +66,21 @@ public class MetricPublishing {
 
     /**
      * Starts the polling that will publish metrics at regular intervals. This start() method should be called by
-     * the main() method of the application.
+     * the main() method of the application. Calling this method more than once is allowed, but will have no effect if
+     * the polling has already been started.
      *
      * @param graphiteConfig Tells the library how to talk to Graphite
      */
     public void start(GraphiteConfig graphiteConfig) {
-        pollScheduler.start();
-        final MetricPoller monitorRegistryMetricPoller = factory.createMonitorRegistryMetricPoller();
-        final List<MetricObserver> observers = Collections.singletonList(createGraphiteObserver(graphiteConfig));
-        final PollRunnable task = factory.createTask(monitorRegistryMetricPoller, observers);
-        pollScheduler.addPoller(task, graphiteConfig.pollintervalseconds(), TimeUnit.SECONDS);
+        synchronized (pollScheduler) {
+            if(!pollScheduler.isStarted()) {
+                pollScheduler.start();
+                final MetricPoller monitorRegistryMetricPoller = factory.createMonitorRegistryMetricPoller();
+                final List<MetricObserver> observers = Collections.singletonList(createGraphiteObserver(graphiteConfig));
+                final PollRunnable task = factory.createTask(monitorRegistryMetricPoller, observers);
+                pollScheduler.addPoller(task, graphiteConfig.pollintervalseconds(), TimeUnit.SECONDS);
+            }
+        }
     }
 
     /**

--- a/src/test/java/com/expedia/www/haystack/metrics/GraphiteConfigImplTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/GraphiteConfigImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.metrics;
 
 import org.junit.Before;

--- a/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.metrics;
 
 import com.netflix.servo.DefaultMonitorRegistry;

--- a/src/test/java/com/expedia/www/haystack/metrics/ServoToInfluxDbViaGraphiteNamingConventionTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/ServoToInfluxDbViaGraphiteNamingConventionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.metrics;
 
 import com.netflix.servo.Metric;


### PR DESCRIPTION
Add missing copyright notices to Java source files.