### PR TITLE
Renamed the createAndRegisterResettingNonRateCounter API to

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,8 +1,11 @@
 # Release Notes
 
+## 0.4.0 / 2017-12-15 Change new API to not include "NonRate" as part of its name
+The renaming of the previous version was not quite complete; the API name (created in 0.2.9) needs to change as well.
+
 ## 0.3.0 / 2017-12-14 Add a configuration to control whether or not the metrics are all transformed to rates
 The NetFlix rule is "all metrics are sent as rates"; this package allows, under configuration, counters to be sent
-as straight counts. Also renamed ResettingNonRateCounter to ResettingCounter
+as straight counts. Also renamed ResettingNonRateCounter to ResettingCounter.
 
 ## 0.2.9 / 2017-12-12 Add MetricObjects.createResettingNonRateCounter()
 Expose a method to allow the creation of the ResettingNonRateCounter provided in 0.2.8.

--- a/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/MetricObjects.java
@@ -106,7 +106,7 @@ public class MetricObjects {
      *                    using upper case for counterName is recommended.
      * @return a new Counter that this method registers in the DefaultMonitorRegistry before returning it.
      */
-    public Counter createAndRegisterResettingNonRateCounter(String subsystem, String application, String klass, String counterName) {
+    public Counter createAndRegisterResettingCounter(String subsystem, String application, String klass, String counterName) {
         final MonitorConfig monitorConfig = buildMonitorConfig(subsystem, application, klass, counterName);
         return checkForExistingCounter(
                 monitorConfig, new ResettingCounter(monitorConfig), RESETTING_NON_RATE_COUNTERS);

--- a/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/MetricObjectsTest.java
@@ -109,30 +109,30 @@ public class MetricObjectsTest {
     }
 
     @Test
-    public void testCreateAndRegisterResettingNonRateCounter() {
+    public void testCreateAndRegisterResettingCounter() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Counter counter = metricObjects.createAndRegisterResettingNonRateCounter(
+        final Counter counter = metricObjects.createAndRegisterResettingCounter(
                 SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME);
 
-        assertsAndVerifiesForCreateAndRegisterResettingNonRateCounter(counter);
+        assertsAndVerifiesForCreateAndRegisterResettingCounter(counter);
     }
 
     @Test
-    public void testCreateAndRegisterExistingResettingNonRateCounter() {
+    public void testCreateAndRegisterExistingResettingCounter() {
         when(mockFactory.getMonitorRegistry()).thenReturn(mockMonitorRegistry);
 
-        final Counter counter = metricObjects.createAndRegisterResettingNonRateCounter(
+        final Counter counter = metricObjects.createAndRegisterResettingCounter(
                 SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME);
-        final Counter existingCounter = metricObjects.createAndRegisterResettingNonRateCounter(
+        final Counter existingCounter = metricObjects.createAndRegisterResettingCounter(
                 SUBSYSTEM, APPLICATION, CLASS, METRIC_NAME);
 
         assertSame(counter, existingCounter);
         verify(mockLogger).warn(String.format(MetricObjects.COUNTER_ALREADY_REGISTERED, existingCounter));
-        assertsAndVerifiesForCreateAndRegisterResettingNonRateCounter(counter);
+        assertsAndVerifiesForCreateAndRegisterResettingCounter(counter);
     }
 
-    private void assertsAndVerifiesForCreateAndRegisterResettingNonRateCounter(Counter counter) {
+    private void assertsAndVerifiesForCreateAndRegisterResettingCounter(Counter counter) {
         assertsAndVerifiesForCreateAndRegister(counter, 4);
         final TagList tagList = counter.getConfig().getTags();
         assertEquals(DataSourceType.COUNTER.getValue(), tagList.getValue(DataSourceType.KEY));


### PR DESCRIPTION
createAndRegisterResettingCounter (the decision about whether or not
to use rates is made independently of the Counter chosen).