### PR TITLE
Ignore IllegalStateException when calling MetricPublishing.stop();

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.6.0 / 2018-02-08 Ignore IllegalStateException in MetricPublishing.stop()
+In case it wasn't started; this solves a problem seen when starting a Spring application that uses Logback. 
+
 ## 0.5.0 / 2018-01-09 Add new API with one more tag
 This was needed for the ERROR_COUNTER use case in the custom logback/log4j appenders, to enable the identification of
 subsystem in the metrics.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-metrics</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/MetricPublishing.java
@@ -88,7 +88,11 @@ public class MetricPublishing {
      * Stops the polling that publishes metrics; for maximum safety, call this method before calling System.exit().
      */
     public void stop() {
-        pollScheduler.stop();
+        try {
+            pollScheduler.stop();
+        } catch(IllegalStateException e) {
+            // The poller wasn't started; just ignore this error
+        }
     }
 
     MetricObserver createGraphiteObserver(GraphiteConfig graphiteConfig) {

--- a/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
@@ -113,7 +113,7 @@ public class MetricPublishingTest {
     }
 
     @Test
-    public void testStart() throws UnknownHostException, InterruptedException {
+    public void testStart() throws InterruptedException {
         final List<MetricObserver> observers = whensForStart();
         when(mockGraphiteConfig.sendasrate()).thenReturn(true);
 
@@ -148,7 +148,7 @@ public class MetricPublishingTest {
         return Collections.singletonList(mockCounterToRateMetricTransform);
     }
 
-    private void verifiesForStart(List<MetricObserver> observers) throws UnknownHostException {
+    private void verifiesForStart(List<MetricObserver> observers) {
         verifiesForAsync(3, mockGraphiteMetricObserver);
         verify(mockFactory).createCounterToRateMetricTransform(mockAsyncMetricObserver, POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
         verifiesForCreateGraphiteObserver(3);
@@ -158,7 +158,7 @@ public class MetricPublishingTest {
     }
 
     @Test
-    public void testCreateGraphiteObserver() throws UnknownHostException {
+    public void testCreateGraphiteObserver() {
         whensForCreateGraphiteObserver();
 
         final MetricObserver metricObserver = metricPublishing.createGraphiteObserver(mockGraphiteConfig);
@@ -201,17 +201,13 @@ public class MetricPublishingTest {
         when(mockGraphiteConfig.pollintervalseconds()).thenReturn(POLL_INTERVAL_SECONDS);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testStopWithoutCallingStartFirst() {
-        try {
-            metricPublishing.stop();
-        } catch (IllegalStateException e) {
-            // PollScheduler is a final class and cannot be mocked with Mockito, so traditional verification of
-            // metricPublishing.stop() cannot be done. Instead, don't call start(), and catch the resulting exception
-            // that will only occur when stop() is called without calling start().
-            assertEquals("scheduler must be started before you stop it", e.getMessage());
-            throw e;
-        }
+        metricPublishing.stop();
+        // PollScheduler is a final class and cannot be mocked with Mockito, so traditional verification of
+        // metricPublishing.stop() cannot be done. Instead, don't call start(), and catch the resulting exception
+        // that will only occur when stop() is called without calling start(). This exception is caught and ignored
+        // by MetricPublishing.stop(). Since it is silently ignored, only code coverage verifies the ignoring behavior.
     }
 
     @Test


### PR DESCRIPTION
Spring applications that use Logback can cause this situation when
resetting the logging system during startup.