### PR TITLE
Count the number of times that MetricPublishing.start() was called

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.9.0 / 2018-03-05 Count the number of times that MetricPublishing.start() was called
+This is needed so that MetricPublishing.stop() will not actually stop the polling thread until the last call to 
+MetricPublishing.start(); Log4j2 behavior at start-up necessitated this change.
+
 ## 0.8.0 / 2018-03-01 Log an informational message when starting metric publishing
 
 ## 0.7.0 / 2018-02-02 Perform environment variable substitution on GraphiteConfig.host()

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-metrics</artifactId>
-    <version>0.8.0</version>
+    <version>0.9.0</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/MetricPublishingTest.java
@@ -133,7 +133,9 @@ public class MetricPublishingTest {
         // Would mock PollScheduler, but it's final; instead, sleep to give mockTask.run() time to be called
         Thread.sleep(1000);
         verifiesForStart(observers);
-        metricPublishing.stop();
+        for(int i = 0 ; i < NUMBER_OF_ITERATIONS_IN_TESTS ; i++) {
+            metricPublishing.stop();
+        }
     }
 
     @Test(expected = OutOfMemoryError.class)


### PR DESCRIPTION
to determine when it's time to actually shut down the metrics polling
when MetricPublishing.stop() is called.